### PR TITLE
Baseline p(boost) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "ore-boost-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "ore-boost-program"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ore-api",
  "ore-boost-api",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "ore-boosts-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "clap 4.5.17",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["api", "cli", "program"]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://ore.supply"

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -194,6 +194,7 @@ pub fn register(signer: Pubkey, payer: Pubkey, proof: Pubkey) -> Instruction {
             AccountMeta::new_readonly(proof, false),
             AccountMeta::new(reservation_pda.0, false),
             AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(sysvar::slot_hashes::ID, false),
         ],
         data: Register {}.to_bytes(),
     }

--- a/program/src/register.rs
+++ b/program/src/register.rs
@@ -1,12 +1,14 @@
+use std::mem::size_of;
+
 use ore_api::state::Proof;
 use ore_boost_api::{consts::RESERVATION, state::Reservation};
-use solana_program::keccak::hashv;
+use solana_program::{keccak::hashv, slot_hashes::SlotHash};
 use steel::*;
 
 /// Registers a reservation account for a miner.
 pub fn process_register(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
     // Load accounts
-    let [signer_info, payer_info, proof_info, reservation_info, system_program] = accounts else {
+    let [signer_info, payer_info, proof_info, reservation_info, system_program, slot_hashes_sysvar] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     signer_info.is_signer()?;
@@ -19,6 +21,7 @@ pub fn process_register(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramRe
         .is_empty()?
         .has_seeds(&[RESERVATION, proof_info.key.as_ref()], &ore_boost_api::ID)?;
     system_program.is_program(&solana_program::system_program::ID)?;
+    slot_hashes_sysvar.is_sysvar(&sysvar::slot_hashes::ID)?;
     
     // Create the reservation account.
     create_account::<Reservation>(
@@ -31,7 +34,10 @@ pub fn process_register(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramRe
     let reservation = reservation_info.as_account_mut::<Reservation>(&ore_boost_api::ID)?;
     reservation.authority = *proof_info.key;
     reservation.boost = Pubkey::default();
-    reservation.noise = hashv(&[proof_info.key.as_ref()]).0;
+    reservation.noise = hashv(&[
+        proof_info.key.as_ref(), 
+        &slot_hashes_sysvar.data.borrow()[0..size_of::<SlotHash>()],
+    ]).0;
     reservation.ts = proof.last_hash_at;
 
     Ok(())

--- a/program/src/rotate.rs
+++ b/program/src/rotate.rs
@@ -4,7 +4,7 @@ use solana_program::{keccak::hashv, log::sol_log};
 use steel::*;
 
 // P(boost) base probability for every miner.
-const BASE_RESERVATION_PROBABILITY: u64 = 50;
+const BASE_RESERVATION_PROBABILITY: u64 = 10;
 
 /// Rotates a reservation to a randomly selected boost in the directory.
 pub fn process_rotate(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {


### PR DESCRIPTION
- Adds a baseline probability `p(boost)` to multiplier reservations that applies uniformly to all miners.
    - Initializes baseline p(boost) at 2%.
    - Provides a lever for us to smoothly phase out the proof-weighted p(boost).
    - Baseline p(boost) will increase 2% every week until it hits 20% and then be phased out entirely for p(boost) = 1.
- Randomizes the initial reservation noise to prevent multiplier manipulation strategy.
- Bumps version to 1.3.0