### PR TITLE
Add an BoostLocked error

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -3,8 +3,8 @@ use steel::*;
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, IntoPrimitive)]
 #[repr(u32)]
 pub enum BoostError {
-    #[error("Dummy")]
-    Dummy = 0,
+    #[error("This boost is curerntly locked for checkpointing. Withdraws will be opened after the checkpoint is finalized.")]
+    BoostLocked,
 }
 
 error!(BoostError);

--- a/program/src/withdraw.rs
+++ b/program/src/withdraw.rs
@@ -1,7 +1,5 @@
 use ore_boost_api::{
-    consts::BOOST,
-    instruction::Withdraw,
-    state::{Boost, Stake},
+    consts::BOOST, error::BoostError, instruction::Withdraw, state::{Boost, Stake}
 };
 use steel::*;
 
@@ -25,7 +23,7 @@ pub fn process_withdraw(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramRes
     let boost = boost_info
         .as_account_mut::<Boost>(&ore_boost_api::ID)?
         .assert_mut(|b| b.mint == *mint_info.key)?
-        .assert_mut(|b| b.locked == 0)?;
+        .assert_mut_err(|b| b.locked == 0, BoostError::BoostLocked.into())?;
     boost_deposits_info
         .is_writable()?
         .as_associated_token_account(boost_info.key, mint_info.key)?;


### PR DESCRIPTION
- Return this error on withdraws if the boost is locked for checkpointing.